### PR TITLE
4 as datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ Setting this option will enable the build only if there is an environment variab
 ### `modify_md`
 
 Setting this option to false will disable the use of `{{ git_revision_date }}` in markdown files. Default is true.
+
+### `as_datetime`
+
+Setting this option to True will output git_revision_date as a python `datetime`. This means you can use jinja2 date formatting, for example as `{{ git_revision_date.strftime('%d %B %Y') }}`. Default is false.

--- a/mkdocs_git_revision_date_plugin/plugin.py
+++ b/mkdocs_git_revision_date_plugin/plugin.py
@@ -1,4 +1,5 @@
 from os import environ
+from datetime import datetime
 
 from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
@@ -10,7 +11,8 @@ from .util import Util
 class GitRevisionDatePlugin(BasePlugin):
     config_scheme = (
         ('enabled_if_env', config_options.Type(string_types)),
-        ('modify_md', config_options.Type(bool, default=True))
+        ('modify_md', config_options.Type(bool, default=True)),
+        ('as_datetime', config_options.Type(bool, default=False)),
     )
 
     def __init__(self):
@@ -32,9 +34,11 @@ class GitRevisionDatePlugin(BasePlugin):
         revision_date = self.util.get_revision_date_for_file(page.file.abs_src_path)
 
         if not revision_date:
-            from datetime import datetime
-            revision_date = datetime.now().date()
+            revision_date = datetime.now().date().strftime('%Y-%m-%d')
             print('WARNING -  %s has no git logs, revision date defaulting to today\'s date' % page.file.src_path)
+
+        if self.config['as_datetime']:
+            revision_date = datetime.strptime(revision_date,'%Y-%m-%d')
 
         page.meta['revision_date'] = revision_date
 


### PR DESCRIPTION
- Adds option to output git-revision-datetime as python `datetime` object
- Consistent output as `str` when there is no revision_date (was `datetime`)
- Updated README