### PR TITLE
Update plugin.py

### DIFF
--- a/mkdocs_git_revision_date_plugin/plugin.py
+++ b/mkdocs_git_revision_date_plugin/plugin.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
-from mkdocs.utils import string_types
 from .util import Util
 
 


### PR DESCRIPTION
Fixes a Regression, cleans up unused import

```
ImportError: cannot import name 'string_types' from 'mkdocs.utils' (/Users/munagekar/../lib/python3.8/site-packages/mkdocs/utils/__init__.py)
```