### PR TITLE
Added 'repo_dir' config argument.

### DIFF
--- a/mkdocs_git_revision_date_plugin/plugin.py
+++ b/mkdocs_git_revision_date_plugin/plugin.py
@@ -12,13 +12,15 @@ class GitRevisionDatePlugin(BasePlugin):
         ('enabled_if_env', config_options.Type(str)),
         ('modify_md', config_options.Type(bool, default=True)),
         ('as_datetime', config_options.Type(bool, default=False)),
+        ('repo_dir', config_options.Type(str, default='.')),
     )
 
     def __init__(self):
         self.enabled = True
-        self.util = Util()
 
     def on_config(self, config):
+        self.util = Util(self.config['repo_dir'])
+
         env_name = self.config['enabled_if_env']
         if env_name:
             self.enabled = environ.get(env_name) == '1'
@@ -63,5 +65,5 @@ class GitRevisionDatePlugin(BasePlugin):
                           revision_date,
                           markdown,
                           flags=re.IGNORECASE)
-            
+
             return markdown

--- a/mkdocs_git_revision_date_plugin/util.py
+++ b/mkdocs_git_revision_date_plugin/util.py
@@ -2,8 +2,8 @@ from git import Git
 
 class Util:
 
-    def __init__(self):
-        self.g = Git()
+    def __init__(self, repo_dir):
+        self.g = Git(repo_dir)
 
     def get_revision_date_for_file(self, path: str):
         return self.g.log(path, n=1, date='short', format='%ad')


### PR DESCRIPTION
Hi, I added a `repo_dir` configuration argument for the case where the `docs_dir` points to a submodule or otherwise nested repo.

In my setup, my `docs_dir` points to "notes", which is a separate private repo containing my Obsidian.md vault.

I explain it here: https://samrambles.com/guides/dotfiles/how-i-setup-this-blog/index.html